### PR TITLE
v0.1.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5] - 2019-10-18
+### Changed
+- Updated dependencies to fix failing tests
+- Fix: SnapshotReading ordering of new events.
+- Expand when expecting version bugfix: MdNode version when Count == 0 and StartIndex > 0 is correctly set to SpecificVersion of (NextVersion - 1), instead of NoVersion.
+- MdHeadManager fixed incorrect casting. StreamDb fixed non-accessible initialization.
+- MdNode ReadFromSnapshot handles NoVersion case.
+
 ## [0.1.0-alpha.4] - 2019-04-16
 ### Changed
 - NetworkDataOps public access modifier.
@@ -58,8 +66,9 @@ Following are moved to SAFE.Data.Common:
 ### Added
 - Migrated project files from old repo.
 
-[Unreleased]: https://github.com/oetyng/SAFE.AppendOnlyDb/compare/dev-v.0.1.0-alpha.4...dev-v0.1.0-alpha.5
-[0.1.0-alpha.4]: https://github.com/oetyng/SAFE.AppendOnlyDb/compare/dev-v.0.1.0-alpha.3...dev-v.0.1.0-alpha.4
+[Unreleased]: https://github.com/oetyng/SAFE.AppendOnlyDb/compare/dev-v0.1.0-alpha.5...dev-v0.1.0-alpha.6
+[0.1.0-alpha.5]: https://github.com/oetyng/SAFE.AppendOnlyDb/compare/dev-v0.1.0-alpha.4...dev-v0.1.0-alpha.5
+[0.1.0-alpha.4]: https://github.com/oetyng/SAFE.AppendOnlyDb/compare/dev-v.0.1.0-alpha.3...dev-v0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/oetyng/SAFE.AppendOnlyDb/compare/dev-v.0.1.0-alpha.2...dev-v.0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/oetyng/SAFE.AppendOnlyDb/compare/dev-v0.1.0-alpha.1...dev-v.0.1.0-alpha.2
 [0.1.0-alpha.1]: https://github.com/oetyng/SAFE.AppendOnlyDb/releases/tag/v0.1.0-alpha.1

--- a/SAFE.AppendOnlyDb.Tests/SAFE.AppendOnlyDb.Tests.csproj
+++ b/SAFE.AppendOnlyDb.Tests/SAFE.AppendOnlyDb.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="MaidSafe.SafeApp" Version="0.2.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0-preview1.19504.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />

--- a/SAFE.AppendOnlyDb/Database/DataTree.cs
+++ b/SAFE.AppendOnlyDb/Database/DataTree.cs
@@ -46,10 +46,10 @@ namespace SAFE.AppendOnlyDb
         IAsyncEnumerable<(ulong, StoredValue)> IStreamAD.GetRangeAsync(ulong from, ulong to)
             => _head.FindRangeAsync(from, to);
 
-        public IOrderedAsyncEnumerable<(ulong, StoredValue)> ReadForwardFromAsync(ulong from)
+        public IAsyncEnumerable<(ulong, StoredValue)> ReadForwardFromAsync(ulong from)
             => _head.ReadToEndAsync(from).OrderBy(c => c.Item1);
 
-        public IOrderedAsyncEnumerable<(ulong, StoredValue)> ReadBackwardsFromAsync(ulong from)
+        public IAsyncEnumerable<(ulong, StoredValue)> ReadBackwardsFromAsync(ulong from)
             => _head.FindRangeAsync(0, from).OrderByDescending(c => c.Item1);
 
         /// <summary>

--- a/SAFE.AppendOnlyDb/Database/Interfaces/IStreamAD.cs
+++ b/SAFE.AppendOnlyDb/Database/Interfaces/IStreamAD.cs
@@ -20,8 +20,8 @@ namespace SAFE.AppendOnlyDb
         /// <returns><see cref="SnapshotReading"/></returns>
         Task<Result<Snapshots.SnapshotReading>> ReadFromSnapshot();
 
-        IOrderedAsyncEnumerable<(ulong, StoredValue)> ReadForwardFromAsync(ulong from);
-        IOrderedAsyncEnumerable<(ulong, StoredValue)> ReadBackwardsFromAsync(ulong from);
+        IAsyncEnumerable<(ulong, StoredValue)> ReadForwardFromAsync(ulong from);
+        IAsyncEnumerable<(ulong, StoredValue)> ReadBackwardsFromAsync(ulong from);
         IAsyncEnumerable<(ulong, StoredValue)> GetRangeAsync(ulong from, ulong to);
 
         IAsyncEnumerable<StoredValue> GetAllValuesAsync();

--- a/SAFE.AppendOnlyDb/Database/StreamDb.cs
+++ b/SAFE.AppendOnlyDb/Database/StreamDb.cs
@@ -14,7 +14,7 @@ namespace SAFE.AppendOnlyDb
         readonly DataTreeFactory _dataTreeFactory;
 
         protected readonly ConcurrentDictionary<string, IStreamAD> _dataTreeCache = new ConcurrentDictionary<string, IStreamAD>();
-        protected ConcurrentDictionary<string, MdLocator> _dataTreeAddresses = new ConcurrentDictionary<string, MdLocator>();
+        protected ConcurrentDictionary<string, MdLocator> _dataTreeAddresses;
 
         public StreamDb(IStreamCollection streams, Network.IMdNodeFactory nodeFactory)
         { 

--- a/SAFE.AppendOnlyDb/Network/MdHeadManager.cs
+++ b/SAFE.AppendOnlyDb/Network/MdHeadManager.cs
@@ -151,7 +151,8 @@ namespace SAFE.AppendOnlyDb.Network
             var locator = mdContainerJson.Parse<MdLocator>();
 
             var dataTreeFactory = new Factories.DataTreeFactory(_nodeFactory);
-            _mdContainerSource = (IValueAD)await dataTreeFactory.LocateAsync(locator, (s) => throw new ArgumentOutOfRangeException("Can only add 999k items to this collection."));
+            var result = await dataTreeFactory.LocateAsync(locator, (s) => throw new ArgumentOutOfRangeException("Can only add 999k items to this collection."));
+            _mdContainerSource = result.Value; // makes sense to check for HasValue?
             var value = await _mdContainerSource.GetValueAsync();
             if (value.HasValue)
                 return value.Value.Parse<MdContainer>();

--- a/SAFE.AppendOnlyDb/Network/Node/MdNode.Read.cs
+++ b/SAFE.AppendOnlyDb/Network/Node/MdNode.Read.cs
@@ -137,13 +137,21 @@ namespace SAFE.AppendOnlyDb.Network
             if (!lastNodeRes.HasValue)
                 return lastNodeRes.CastError<IMdNode, Snapshots.SnapshotReading>();
             var lastNode = lastNodeRes.Value;
-            var since = FindRangeAsync(lastNode.StartIndex, (ulong)lastNode.Version.Value);
-            var reading = new Snapshots.SnapshotReading
+
+            switch (lastNode.Version)
             {
-                SnapshotMap = lastNode.Snapshot,
-                NewEvents = since
-            };
-            return Result.OK(reading);
+                case NoVersion nv:
+                    return new DataNotFound<Snapshots.SnapshotReading>("No data in the stream.");
+                case SpecificVersion sv:
+                    var reading = new Snapshots.SnapshotReading
+                    {
+                        SnapshotMap = lastNode.Snapshot,
+                        NewEvents = FindRangeAsync(lastNode.StartIndex, (ulong)sv.Value)
+                    };
+                    return Result.OK(reading);
+                default:
+                    return new ArgumentOutOfRange<Snapshots.SnapshotReading>(nameof(lastNode.Version));
+            }
         }
 
 

--- a/SAFE.AppendOnlyDb/Network/Node/MdNode.Read.cs
+++ b/SAFE.AppendOnlyDb/Network/Node/MdNode.Read.cs
@@ -147,6 +147,7 @@ namespace SAFE.AppendOnlyDb.Network
                     {
                         SnapshotMap = lastNode.Snapshot,
                         NewEvents = FindRangeAsync(lastNode.StartIndex, (ulong)sv.Value)
+                            .OrderBy(c => c.Item1)
                     };
                     return Result.OK(reading);
                 default:

--- a/SAFE.AppendOnlyDb/Network/Node/MdNode.cs
+++ b/SAFE.AppendOnlyDb/Network/Node/MdNode.cs
@@ -25,7 +25,7 @@ namespace SAFE.AppendOnlyDb.Network
         public int Level => _metadata.Level;
         public MdType Type => Level > 0 ? MdType.Pointers : MdType.Values;
         public MdLocator MdLocator => _dataOps.MdLocator;
-        public ExpectedVersion Version => Count == 0 ? ExpectedVersion.None : ExpectedVersion.Specific(NextVersion - 1);
+        public ExpectedVersion Version => Count == 0 && StartIndex == 0 ? ExpectedVersion.None : ExpectedVersion.Specific(NextVersion - 1);
 
         public IMdNodeFactory NodeFactory => _dataOps.NodeFactory;
 

--- a/SAFE.AppendOnlyDb/SAFE.AppendOnlyDb.csproj
+++ b/SAFE.AppendOnlyDb/SAFE.AppendOnlyDb.csproj
@@ -12,7 +12,7 @@
     <Copyright>2019 oetyng</Copyright>
     <RepositoryUrl>https://github.com/oetyng/SAFE.AppendOnlyDb</RepositoryUrl>
     <PackageLicenseUrl>https://licenses.nuget.org/MIT</PackageLicenseUrl>
-    <Version>0.1.0-alpha.4</Version>
+    <Version>0.1.0-alpha.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SAFE.AppendOnlyDb/SAFE.AppendOnlyDb.csproj
+++ b/SAFE.AppendOnlyDb/SAFE.AppendOnlyDb.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MaidSafe.SafeApp" Version="0.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="SAFE.Data.Common" Version="0.2.0" />
-    <PackageReference Include="System.Interactive.Async" Version="4.0.0-preview.1.build.745" />
+    <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated dependencies to fix failing tests
- Fix: SnapshotReading ordering of new events.
- Expand when expecting version bugfix: MdNode version when Count == 0 and StartIndex > 0 is correctly set to SpecificVersion of (NextVersion - 1), instead of NoVersion.
- MdHeadManager fixed incorrect casting. StreamDb fixed non-accessible initialization.
- MdNode ReadFromSnapshot handles NoVersion case.